### PR TITLE
use base64.b64encode() not encodestring()

### DIFF
--- a/OPSI/Backend/HostControl.py
+++ b/OPSI/Backend/HostControl.py
@@ -97,7 +97,7 @@ class RpcThread(KillableThread):
 				connection.putheader('content-type', 'application/json')
 				connection.putheader('content-length', str(len(query)))
 				auth = u'{0}:{1}'.format(self.username, self.password)
-				connection.putheader('Authorization', 'Basic ' + base64.encodestring(auth.encode('latin-1')).strip())
+				connection.putheader('Authorization', 'Basic ' + base64.b64encode(auth.encode('latin-1')).strip())
 				connection.endheaders()
 				connection.send(query)
 

--- a/OPSI/Backend/JSONRPC.py
+++ b/OPSI/Backend/JSONRPC.py
@@ -699,7 +699,7 @@ class JSONRPCBackend(Backend):
 		headers['content-length'] = len(data)
 
 		auth = (self._username + u':' + self._password).encode('latin-1')
-		headers['Authorization'] = 'Basic ' + base64.encodestring(auth).strip().replace('\n', '')
+		headers['Authorization'] = 'Basic ' + base64.b64encode(auth).strip().replace('\n', '')
 
 		if self._sessionId:
 			headers['Cookie'] = self._sessionId

--- a/OPSI/Util/HTTP.py
+++ b/OPSI/Util/HTTP.py
@@ -476,14 +476,14 @@ class HTTPConnectionPool(object):
 					logger.info(u"Encoding authorization")
 					randomKey = randomString(32).encode('latin-1')
 					encryptedKey = encryptWithPublicKeyFromX509CertificatePEMFile(randomKey, self.serverCertFile)
-					headers['X-opsi-service-verification-key'] = base64.encodestring(encryptedKey)
+					headers['X-opsi-service-verification-key'] = base64.b64encode(encryptedKey)
 					for key, value in headers.items():
 						if key.lower() == 'authorization':
 							if value.lower().startswith('basic'):
 								value = value[5:].strip()
 							value = base64.decodestring(value).strip()
 							encodedAuth = encryptWithPublicKeyFromX509CertificatePEMFile(value, self.serverCertFile)
-							headers[key] = 'Opsi ' + base64.encodestring(encodedAuth).strip()
+							headers[key] = 'Opsi ' + base64.b64encode(encodedAuth).strip()
 				except Exception as error:
 					logger.logException(error, LOG_INFO)
 					logger.critical(u"Cannot verify server based on certificate file {0!r}: {1}", self.serverCertFile, error)

--- a/OPSI/Util/MessageBus.py
+++ b/OPSI/Util/MessageBus.py
@@ -538,7 +538,7 @@ class MessageBusWebsocketClient(MessageBusClient):
 		headers = 'GET %s HTTP/1.1\r\n' % self._baseUrl
 		if self.__username and self.__password:
 			auth = (self.__username + u':' + self.__password).encode('latin-1')
-			headers += 'Authorization: Basic ' + base64.encodestring(auth).strip()
+			headers += 'Authorization: Basic ' + base64.b64encode(auth).strip()
 		headers += 'Upgrade: websocket\r\n'
 		headers += 'Connection: Upgrade\r\n'
 		headers += 'Host: %s:%d\r\n' % (self._host, self._port)

--- a/OPSI/Util/Repository.py
+++ b/OPSI/Util/Repository.py
@@ -854,7 +854,7 @@ class HTTPRepository(Repository):
 			logger.addConfidentialString(self._password)
 
 		auth = u'%s:%s' % (self._username, self._password)
-		self._auth = 'Basic '+ base64.encodestring(auth.encode('latin-1')).strip()
+		self._auth = 'Basic '+ base64.b64encode(auth.encode('latin-1')).strip()
 		self._proxy = None
 
 		if proxy:
@@ -871,7 +871,7 @@ class HTTPRepository(Repository):
 				if ':' in proxyUsername:
 					proxyUsername, proxyPassword = proxyUsername.split(':', 1)
 				auth = u'%s:%s' % (proxyUsername, proxyPassword)
-				self._auth = 'Basic '+ base64.encodestring(auth.encode('latin-1')).strip()
+				self._auth = 'Basic '+ base64.b64encode(auth.encode('latin-1')).strip()
 			proxyPort = forceInt(match.group(3))
 			if self._username and self._password:
 				self._url = u'%s://%s:%s@%s:%d%s' % (self._protocol, self._username, self._password, self._host, self._port, self._path)

--- a/OPSI/Util/__init__.py
+++ b/OPSI/Util/__init__.py
@@ -159,7 +159,7 @@ def librsyncSignature(filename, base64Encoded=True):
 				sig = sf.read()
 
 				if base64Encoded:
-					sig = base64.encodestring(sig)
+					sig = base64.b64encode(sig)
 
 				return sig
 	except Exception as e:

--- a/OPSI/ldaptor/entry.py
+++ b/OPSI/ldaptor/entry.py
@@ -14,7 +14,7 @@ def sshaDigest(passphrase, salt=None):
     s = sha.sha()
     s.update(passphrase)
     s.update(salt)
-    encoded = base64.encodestring(s.digest()+salt).rstrip()
+    encoded = base64.b64encode(s.digest()+salt).rstrip()
     crypt = '{SSHA}' + encoded
     return crypt
 

--- a/OPSI/ldaptor/protocols/ldap/ldif.py
+++ b/OPSI/ldaptor/protocols/ldap/ldif.py
@@ -15,7 +15,7 @@ TODO implement rest of syntax from RFC2849
 import base64
 
 def base64_encode(s):
-    return ''.join(base64.encodestring(s).split('\n'))+'\n'
+    return ''.join(base64.b64encode(s).split('\n'))+'\n'
 
 def attributeAsLDIF_base64(attribute, value):
     return "%s:: %s" % (attribute, base64_encode(value))

--- a/OPSI/web2/http_headers.py
+++ b/OPSI/web2/http_headers.py
@@ -1518,7 +1518,7 @@ generator_entity_headers = {
     'Content-Language':(generateList, singleHeader),
     'Content-Length':(str, singleHeader),
     'Content-Location':(str, singleHeader),
-    'Content-MD5':(base64.encodestring, lambda x: x.strip("\n"), singleHeader),
+    'Content-MD5':(base64.b64encode, lambda x: x.strip("\n"), singleHeader),
     'Content-Range':(generateContentRange, singleHeader),
     'Content-Type':(generateContentType, singleHeader),
     'Expires':(generateDateTime, singleHeader),

--- a/OPSI/web2/test/test_httpauth.py
+++ b/OPSI/web2/test/test_httpauth.py
@@ -42,7 +42,7 @@ class BasicAuthTestCase(unittest.TestCase):
         self.password = 'S3CuR1Ty'
 
     def testUsernamePassword(self):
-        response = base64.encodestring('%s:%s' % (
+        response = base64.b64encode('%s:%s' % (
                 self.username,
                 self.password))
 
@@ -50,7 +50,7 @@ class BasicAuthTestCase(unittest.TestCase):
         self.failUnless(creds.checkPassword(self.password))
 
     def testIncorrectPassword(self):
-        response = base64.encodestring('%s:%s' % (
+        response = base64.b64encode('%s:%s' % (
                 self.username,
                 'incorrectPassword'))
 
@@ -58,7 +58,7 @@ class BasicAuthTestCase(unittest.TestCase):
         self.failIf(creds.checkPassword(self.password))
 
     def testIncorrectPadding(self):
-        response = base64.encodestring('%s:%s' % (
+        response = base64.b64encode('%s:%s' % (
                 self.username,
                 self.password))
 
@@ -68,7 +68,7 @@ class BasicAuthTestCase(unittest.TestCase):
         self.failUnless(creds.checkPassword(self.password))
 
     def testInvalidCredentials(self):
-        response = base64.encodestring(self.username)
+        response = base64.b64encode(self.username)
 
         self.assertRaises(error.LoginFailed,
                           self.credentialFactory.decode,
@@ -551,7 +551,7 @@ class HTTPAuthResourceTest(test_server.BaseCase):
                                         self.portal,
                                         interfaces=(IHTTPUser,))
 
-        credentials = base64.encodestring('username:password')
+        credentials = base64.b64encode('username:password')
 
         d = self.assertResponse((root, 'http://localhost/',
                                  {'authorization': ('basic', credentials)}),
@@ -636,7 +636,7 @@ class HTTPAuthResourceTest(test_server.BaseCase):
                                         self.portal,
                                         interfaces=(IHTTPUser,))
 
-        credentials = base64.encodestring('bad:credentials')
+        credentials = base64.b64encode('bad:credentials')
 
         d = self.assertResponse(
             (root, 'http://localhost/',
@@ -660,7 +660,7 @@ class HTTPAuthResourceTest(test_server.BaseCase):
                                         self.portal,
                                         interfaces=(IHTTPUser,))
 
-        credentials = base64.encodestring('username:password')
+        credentials = base64.b64encode('username:password')
 
         d = self.assertResponse((root, 'http://localhost/',
                                  {'authorization': ('basic', credentials)}),
@@ -726,7 +726,7 @@ class HTTPAuthResourceTest(test_server.BaseCase):
             interfaces=(IHTTPUser,))
 
         def respondBasic(ign):
-            credentials = base64.encodestring('username:password')
+            credentials = base64.b64encode('username:password')
 
             d = self.assertResponse((root, 'http://localhost/',
                                      {'authorization':
@@ -765,7 +765,7 @@ class HTTPAuthResourceTest(test_server.BaseCase):
                                         self.portal,
                                         interfaces=(IHTTPUser,))
 
-        credentials = base64.encodestring('username:password')
+        credentials = base64.b64encode('username:password')
 
         d = self.assertResponse((root, 'http://localhost/foo/bar/baz/bax',
                                  {'authorization': ('basic', credentials)}),
@@ -791,7 +791,7 @@ class HTTPAuthResourceTest(test_server.BaseCase):
                                         self.portal,
                                         interfaces=(IHTTPUser,))
 
-        credentials = base64.encodestring('Not Good Credentials')
+        credentials = base64.b64encode('Not Good Credentials')
 
         d = self.assertResponse((root, 'http://localhost/',
                                  {'authorization': ('basic', credentials)}),
@@ -848,7 +848,7 @@ class HTTPAuthResourceTest(test_server.BaseCase):
                                         interfaces = (IHTTPUser,))
 
         def _tryAuthenticate(result):
-            credentials = base64.encodestring('username:password')
+            credentials = base64.b64encode('username:password')
 
             d2 = self.assertResponse(
                 (root, 'http://localhost/',
@@ -926,7 +926,7 @@ class HTTPAuthResourceTest(test_server.BaseCase):
             self.assertEquals(response.headers.getHeader('WWW-Authenticate'),
                               [('basic', {'realm': "test realm"})])
 
-            credentials = base64.encodestring('username:password')
+            credentials = base64.b64encode('username:password')
 
             request.headers.setHeader('authorization',
                                       ['basic', credentials])


### PR DESCRIPTION
base64.b64encode() inserts \n after 72 cols encodestring() does not.

This should be the correct method as http auth header does not allow \n
anyway.

This is not well tested as i do not have a working test suit available for now. Please give it a test run.
I am currently running this to fix the internal uib#2016062210000015 ticket.