### PR TITLE
use base64.b64encode() not encodestring()

### DIFF
--- a/OPSI/Backend/HostControl.py
+++ b/OPSI/Backend/HostControl.py
@@ -97,7 +97,7 @@ class RpcThread(KillableThread):
 				connection.putheader('content-type', 'application/json')
 				connection.putheader('content-length', str(len(query)))
 				auth = u'{0}:{1}'.format(self.username, self.password)
-				connection.putheader('Authorization', 'Basic ' + base64.encodestring(auth.encode('latin-1')).strip())
+				connection.putheader('Authorization', 'Basic ' + base64.b64encode(auth.encode('latin-1')).strip())
 				connection.endheaders()
 				connection.send(query)
 

--- a/OPSI/Backend/JSONRPC.py
+++ b/OPSI/Backend/JSONRPC.py
@@ -699,7 +699,7 @@ class JSONRPCBackend(Backend):
 		headers['content-length'] = len(data)
 
 		auth = (self._username + u':' + self._password).encode('latin-1')
-		headers['Authorization'] = 'Basic ' + base64.encodestring(auth).strip().replace('\n', '')
+		headers['Authorization'] = 'Basic ' + base64.b64encode(auth).strip().replace('\n', '')
 
 		if self._sessionId:
 			headers['Cookie'] = self._sessionId

--- a/OPSI/Util/HTTP.py
+++ b/OPSI/Util/HTTP.py
@@ -476,14 +476,14 @@ class HTTPConnectionPool(object):
 					logger.info(u"Encoding authorization")
 					randomKey = randomString(32).encode('latin-1')
 					encryptedKey = encryptWithPublicKeyFromX509CertificatePEMFile(randomKey, self.serverCertFile)
-					headers['X-opsi-service-verification-key'] = base64.encodestring(encryptedKey)
+					headers['X-opsi-service-verification-key'] = base64.b64encode(encryptedKey)
 					for key, value in headers.items():
 						if key.lower() == 'authorization':
 							if value.lower().startswith('basic'):
 								value = value[5:].strip()
 							value = base64.decodestring(value).strip()
 							encodedAuth = encryptWithPublicKeyFromX509CertificatePEMFile(value, self.serverCertFile)
-							headers[key] = 'Opsi ' + base64.encodestring(encodedAuth).strip()
+							headers[key] = 'Opsi ' + base64.b64encode(encodedAuth).strip()
 				except Exception as error:
 					logger.logException(error, LOG_INFO)
 					logger.critical(u"Cannot verify server based on certificate file {0!r}: {1}", self.serverCertFile, error)

--- a/OPSI/Util/MessageBus.py
+++ b/OPSI/Util/MessageBus.py
@@ -538,7 +538,7 @@ class MessageBusWebsocketClient(MessageBusClient):
 		headers = 'GET %s HTTP/1.1\r\n' % self._baseUrl
 		if self.__username and self.__password:
 			auth = (self.__username + u':' + self.__password).encode('latin-1')
-			headers += 'Authorization: Basic ' + base64.encodestring(auth).strip()
+			headers += 'Authorization: Basic ' + base64.b64encode(auth).strip()
 		headers += 'Upgrade: websocket\r\n'
 		headers += 'Connection: Upgrade\r\n'
 		headers += 'Host: %s:%d\r\n' % (self._host, self._port)

--- a/OPSI/Util/Repository.py
+++ b/OPSI/Util/Repository.py
@@ -854,7 +854,7 @@ class HTTPRepository(Repository):
 			logger.addConfidentialString(self._password)
 
 		auth = u'%s:%s' % (self._username, self._password)
-		self._auth = 'Basic '+ base64.encodestring(auth.encode('latin-1')).strip()
+		self._auth = 'Basic '+ base64.b64encode(auth.encode('latin-1')).strip()
 		self._proxy = None
 
 		if proxy:
@@ -871,7 +871,7 @@ class HTTPRepository(Repository):
 				if ':' in proxyUsername:
 					proxyUsername, proxyPassword = proxyUsername.split(':', 1)
 				auth = u'%s:%s' % (proxyUsername, proxyPassword)
-				self._auth = 'Basic '+ base64.encodestring(auth.encode('latin-1')).strip()
+				self._auth = 'Basic '+ base64.b64encode(auth.encode('latin-1')).strip()
 			proxyPort = forceInt(match.group(3))
 			if self._username and self._password:
 				self._url = u'%s://%s:%s@%s:%d%s' % (self._protocol, self._username, self._password, self._host, self._port, self._path)


### PR DESCRIPTION
encodestring() inserts \n after 72 cols base64.b64encode() does not.

This should be the correct method as http auth header does not allow \n
anyway.

This is not well tested as i do not have a working test suit available for now. Please give it a test run.
I am currently running this to fix the internal uib#2016062210000015 ticket.