### PR TITLE
Extract cpio archives with --no-preserve-owner

### DIFF
--- a/OPSI/Util/File/Archive/__init__.py
+++ b/OPSI/Util/File/Archive/__init__.py
@@ -436,7 +436,7 @@ class CpioArchive(BaseArchive, PigzMixin):
 			curDir = os.path.abspath(os.getcwd())
 			os.chdir(targetPath)
 			try:
-				command = u'%s "%s" | %s --quiet -idumv %s' % (cat, self._filename, System.which('cpio'), include)
+				command = u'%s "%s" | %s --quiet -idumv --no-preserve-owner %s' % (cat, self._filename, System.which('cpio'), include)
 				self._extract(command, fileCount)
 			finally:
 				os.chdir(curDir)


### PR DESCRIPTION
In some circumstances extraction can fail if the archive contains files with high uid/gid that may not be supported properly on the host system. Extracting with "--no-preserve-owner" should be save since permissions are reset anyway with opsi-set-rights (I think).

I ran into this issue on an LXD environment: opsi-server runs in an unpriviledged LXD container, so UIDs are limited to 65536. Then a package file was to be installed that would extract a file with UID > 200000. This failed with an error "Cannot change ownership to uid 216408, gid 992: Invalid argument".

Other people had the problem before with an nfs-mounted opsi-directory: https://forum.opsi.org/viewtopic.php?f=8&t=4614&p=22344&hilit=owner#p22344