### PR TITLE
fixed KeyError when running old style opsi-backup

### DIFF
--- a/OPSI/Util/File/Opsi/__init__.py
+++ b/OPSI/Util/File/Opsi/__init__.py
@@ -1498,13 +1498,13 @@ element of the tuple is replace with the second element.
 
 	def _addChecksumFile(self):
 		string = StringIO()
-		size = 0
+
 		for path, checksum in self._filemap.items():
-			size += string.write(f"{checksum} {path}\n")
+			string.write(f"{checksum} {path}\n")
 		string.seek(0)
 
 		info = tarfile.TarInfo(name=f"{self.CONTROL_DIR}/checksums")
-		info.size = size
+		info.size = len(string.getvalue().encode())
 
 		self.addfile(info, BytesIO(string.getvalue().encode()))
 


### PR DESCRIPTION
I got a KeyError when I tried to run opsi-backup in advance for migrating to opsi 4.3. It doesn't matter the version of the script, it also appears in the recent github version.

[7] [2024-02-29 12:09:29.573] [               ] 'CONTENT/CONF/package-updater.repos.d/uib-macos.repo'   (Backup.py:141)
Traceback (most recent call last):
  File "OPSI/Util/Task/Backup.py", line 127, in create
  File "OPSI/Util/Task/Backup.py", line 181, in verify
  File "OPSI/Util/File/Opsi/__init__.py", line 1522, in verify
KeyError: 'CONTENT/CONF/package-updater.repos.d/uib-macos.repo'
[6] [2024-02-29 12:09:29.574] [               ] 'CONTENT/CONF/package-updater.repos.d/uib-macos.repo'   (opsibackup.py:168)
Traceback (most recent call last):
  File "opsiutils/opsibackup.py", line 166, in main
  File "opsiutils/opsibackup.py", line 150, in backup_main
  File "OPSI/Util/Task/Backup.py", line 142, in create
  File "OPSI/Util/Task/Backup.py", line 127, in create
  File "OPSI/Util/Task/Backup.py", line 181, in verify
  File "OPSI/Util/File/Opsi/__init__.py", line 1522, in verify
KeyError: 'CONTENT/CONF/package-updater.repos.d/uib-macos.repo'

ERROR: 'CONTENT/CONF/package-updater.repos.d/uib-macos.repo'


After debugging the code, I figured out, that in my case 3 characters cut off from the last line of the CONTROL/checksum file. 

![Screenshot_20240228_141028](https://github.com/opsi-org/python-opsi/assets/6191971/df451f76-f51d-4615-afd0-dab11fe5a705)


```{python}  
def _addChecksumFile(self):
		string = StringIO()
		size = 0
		for path, checksum in self._filemap.items():
			size += string.write(f"{checksum} {path}\n")
		string.seek(0)

		info = tarfile.TarInfo(name=f"{self.CONTROL_DIR}/checksums")
		info.size = size

		self.addfile(info, BytesIO(string.getvalue().encode()))
```

```{python}
size += string.write(f"{checksum} {path}\n")
``` 
can't be used for determining the size of the string. After encode() is called, the BytesIO will hold the encoded string, which are possibly have umlauts, which are 2-bytes wide or more. In my case I had 3 umlauts ä, ö and ü. (3 chars missing)

This my intuitive  approach to address the issue. If somebody knows a better approach, I'm open. Maybe the _addSysInfoFile shoud be also fixed? 

```{python}
...
		for path, checksum in self._filemap.items():
			string.write(f"{checksum} {path}\n")
		string.seek(0)

		info = tarfile.TarInfo(name=f"{self.CONTROL_DIR}/checksums")
		info.size = len(string.getvalue().encode())
...
``` 

